### PR TITLE
Roll back toml dependency to 0.1.28 so url-0.5.9 parses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
  "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.1.30"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
When cargo 0.10.0 was released the latest version of toml was 0.1.28,
which allows malformed TOML where table entries don't have a newline
between the header and the first key.

Toml 0.1.29 disabled this by default and later versions of cargo pass
a flag to get the compatibility mode.

Until the next version of cargo is released, roll back the toml dependency
for cargo-vendor to 0.1.28 to match the behavior of cargo 0.10.0.

Fixes: #6