### PR TITLE
Add another git related clause to file copying.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,11 +282,13 @@ fn cp_r(src: &Path,
     for entry in try!(src.read_dir()) {
         let entry = try!(entry);
 
-        // Skip .gitattributes as they're not relevant to builds most of the
+        // Skip git config files as they're not relevant to builds most of the
         // time and if we respect them (e.g. in git) then it'll probably mess
         // with the checksums.
-        if entry.file_name().to_str() == Some(".gitattributes") {
-            continue
+        match entry.file_name().to_str() {
+            Some(".gitattribute") => continue,
+            Some(".gitignore") => continue,
+            _ => ()
         }
 
         let src = entry.path();


### PR DESCRIPTION
Having a .gitignore file stops some vendored files to be pushed
to the repo. This breaks subsequent builds.

In my local tests this PR fixes Issue #39.