### PR TITLE
ignore .orig and .rej files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,12 +282,17 @@ fn cp_r(src: &Path,
     for entry in try!(src.read_dir()) {
         let entry = try!(entry);
 
-        // Skip git config files as they're not relevant to builds most of the
-        // time and if we respect them (e.g. in git) then it'll probably mess
-        // with the checksums.
+        // Skip git config files and SCM backup/reject files as they're not
+        // relevant to builds most of the time and if we respect them (e.g. in
+        // git) then it'll probably mess with the checksums.
         match entry.file_name().to_str() {
             Some(".gitattribute") => continue,
             Some(".gitignore") => continue,
+            Some(filename) => {
+                if filename.ends_with(".orig") || filename.ends_with(".rej") {
+                    continue;
+                }
+            }
             _ => ()
         }
 

--- a/tests/vendor.rs
+++ b/tests/vendor.rs
@@ -270,3 +270,22 @@ fn delete_old_crates() {
     assert!(lock.contains("version = \"0.3.5\""));
     assert!(!dir.join("vendor/bitflags/Cargo.toml").exists());
 }
+
+#[test]
+fn ignore_files() {
+    let dir = dir();
+
+    file(&dir, "Cargo.toml", r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [dependencies]
+        url = "=1.4.1"
+    "#);
+    file(&dir, "src/lib.rs", "");
+
+    run(&mut vendor(&dir));
+    let csum = read(&dir.join("vendor/url/.cargo-checksum.json"));
+    assert!(!csum.contains("\"Cargo.toml.orig\""));
+}


### PR DESCRIPTION
It's a bad idea in general to have files named *.orig and *.rej in the tree since those extensions are used by SCM for conflicts.