### PR TITLE
Build source bundle including vendored dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,24 @@ notifications:
 
 before_deploy:
   - name="cargo-vendor-$TRAVIS_TAG-$TARGET"
+  - depsname="cargo-vendor-src-$TRAVIS_TAG"
   - mkdir $name
   - cp target/$TARGET/release/cargo-vendor $name/
   - cp README.md LICENSE-MIT LICENSE-APACHE $name/
   - tar czvf $name.tar.gz $name
+  - mkdir $depsname
+  - git archive HEAD | tar -x -C $depsname
+  - PATH="./target/$TARGET/release:$PATH" cargo vendor
+  - mv vendor $depsname/
+  - tar czvf $depsname.tar.gz $depsname
 
 deploy:
   api_key:
     secure: "feOj0C6YpcKzCZ5mvQi9H/OlHAPnk1FnDKP6+j1vDby+BoTe6Pzv2L068am4BzB3udU7ZwNfeBuZiGQE0LskLIMtc7TpcWyEr7nPfxbzIRYvR4dRKOoBoQdaS0TzkEm+lDQH/3ybyTipbnAiEAZtAgThh2u55tVmNg3PZAQnxlbkcPCTCTh296gcxfcvL3Espzrv7YhFJGjOKmMzTWQxZKNPdrwXhwUbRUziTlKeDypMmlxB3NpjCsewyT0O6ceLZBW0AnmftmS3MI0ZFC9DCDmHhG8Q88ndEjVzDZ0CozKY4aFKju6CG5sYYLqpgC70N138oWi4iGRLHY+M7MyuRt6EHRhuvkY/3GjhhLthCDQX/j0SfH9y4cNFB4kRx0zOBXiq1gb0q8ZZ2MH/WAptBnnDGzMiZrvdfM8rL7ptCApLDKrOEIPwh9vqKaqko1UDidh3Kz+YMb2Q5l0Ludc4nJdMEcnO9wpqPnR5IH2a91e2edRJ9wcOeva/FU7FoB6COAjIjm163VuH/uv/OT9X7M416iNHrIdxzvMxDLqUpfUlLVbHOrX4mta4GwMQPVZNX7ez6OBtripwRnSDRjDHVZcaQiRuANvzvfWHEPh6UmSMUdDXJZSoK5L6gQPjDUNWbtOU5pu0LWV/6V2ukjxi6uOhmfYTO9vjrr5EOhNe7hY="
   file_glob: true
-  file: cargo-vendor-$TRAVIS_TAG-$TARGET.tar.gz
+  file:
+    - cargo-vendor-$TRAVIS_TAG-$TARGET.tar.gz
+    - cargo-vendor-src-$TRAVIS_TAG.tar.gz
   on:
     condition: $DEPLOY = 1
     tags: true


### PR DESCRIPTION
This simplifies boostrapping as one can just download the bundle
including all dependencies.

Closes #50