### PR TITLE
preserve crate whose src dir is in the local_dst dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -283,9 +283,10 @@ fn sync(workspaces: &[Workspace],
     }
 
     // add our vendored source
+    let dir = config.cwd().join(local_dst);
     let mut config = BTreeMap::new();
     config.insert("vendored-sources".to_string(), VendorSource::Directory {
-        directory: canonical_local_dst,
+        directory: dir.to_path_buf(),
     });
 
     // replace original sources with vendor

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,8 +187,9 @@ fn sync(workspaces: &[Workspace],
         for pkg in resolve.iter() {
             if pkg.source_id().is_path() {
                 let path = pkg.source_id().url().to_file_path().expect("path");
-                if path.starts_with(canonical_local_dst.as_path()) {
-                    added_crates.push(path);
+                let canonical_path = path.canonicalize().unwrap_or(path.to_path_buf());
+                if canonical_path.starts_with(canonical_local_dst.as_path()) {
+                    added_crates.push(canonical_path);
                 }
                 continue
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,7 @@ fn sync(workspaces: &[Workspace],
         explicit_version: bool,
         no_delete: bool,
         disallow_duplicates: bool) -> CargoResult<VendorConfig> {
+    let canonical_local_dst = local_dst.canonicalize().unwrap_or(local_dst.to_path_buf());
     let mut ids = BTreeMap::new();
     let mut added_crates = Vec::new();
     for ws in workspaces {
@@ -186,7 +187,7 @@ fn sync(workspaces: &[Workspace],
         for pkg in resolve.iter() {
             if pkg.source_id().is_path() {
                 let path = pkg.source_id().url().to_file_path().expect("path");
-                if path.starts_with(local_dst) {
+                if path.starts_with(canonical_local_dst.as_path()) {
                     added_crates.push(path);
                 }
                 continue
@@ -217,7 +218,7 @@ fn sync(workspaces: &[Workspace],
         map.insert(id.version(), id.source_id());
     }
 
-    let existing_crates = local_dst.read_dir().map(|iter| {
+    let existing_crates = canonical_local_dst.read_dir().map(|iter| {
         iter.filter_map(|e| e.ok())
             .filter(|e| e.path().join("Cargo.toml").exists())
             .map(|e| e.path())
@@ -245,7 +246,7 @@ fn sync(workspaces: &[Workspace],
             // Eg vendor/futures
             id.name().to_string()
         };
-        let dst = local_dst.join(&dst_name);
+        let dst = canonical_local_dst.join(&dst_name);
         added_crates.push(dst.clone());
         sources.insert(id.source_id());
 
@@ -282,10 +283,9 @@ fn sync(workspaces: &[Workspace],
     }
 
     // add our vendored source
-    let dir = config.cwd().join(local_dst);
     let mut config = BTreeMap::new();
     config.insert("vendored-sources".to_string(), VendorSource::Directory {
-        directory: dir.to_path_buf(),
+        directory: canonical_local_dst,
     });
 
     // replace original sources with vendor


### PR DESCRIPTION
The fix for [bug 1323557](https://bugzilla.mozilla.org/show_bug.cgi?id=1323557) was necessary but isn't sufficient to enable the workflow described in [comment 17 on that bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1323557#c17): "Nowadays we should have enough support in Cargo that all you need to do is to add [patch.crates-io] pointing directly at the sources in third_party."

The issue is that cargo-vendor::sync() ignores all path-based crates when determining the set of added_crates, then it removes all existing_crates that aren't in added_crates, which causes it to remove the source dir of a crate whose [patches.crates-io] entry points to a source dir in third_party.

This change adds those source dirs to added_crates, so they don't get removed.

(I considered creating a separate collection, something like "ignored_crates," for them, since it's arguably inaccurate to describe them as "added." But added_crates isn't used for anything other than determining which existing_crates to remove, and these are arguably "added" by the developer, so it's sufficient and perhaps even optimal to collect them in added_crates.)