### PR TITLE
ignore *-sys subdir when vendoring files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,9 @@ fn cp_r(src: &Path,
                 if filename.ends_with(".orig") || filename.ends_with(".rej") {
                     continue;
                 }
+                if filename.ends_with("-sys") && entry.metadata()?.is_dir() {
+                    continue;
+                }
             }
             _ => ()
         }

--- a/tests/vendor.rs
+++ b/tests/vendor.rs
@@ -292,6 +292,26 @@ fn ignore_files() {
 }
 
 #[test]
+fn ignore_sys_subdir() {
+    let dir = dir();
+
+    file(&dir, "Cargo.toml", r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [dependencies.curl]
+        git = 'https://github.com/alexcrichton/curl-rust'
+        rev = '0eb2cbb158b4263aaad03c6ebc1468adf9248c6e'
+    "#);
+    file(&dir, "src/lib.rs", "");
+
+    run(&mut vendor(&dir));
+    let csum = read(&dir.join("vendor/curl/.cargo-checksum.json"));
+    assert!(!csum.contains("curl-sys"));
+}
+
+#[test]
 fn git_simple() {
     let dir = dir();
 


### PR DESCRIPTION
When vendoring a package from a Git repository that has a *-sys subdirectory—such as [lmdb-rs](https://github.com/danburkert/lmdb-rs), [rusqlite](https://github.com/jgallagher/rusqlite), [rust-openssl](https://github.com/sfackler/rust-openssl), [imgui-rs](https://github.com/Gekkio/imgui-rs), and [curl-rust](https://github.com/alexcrichton/curl-rust/)—cargo-vendor includes the *-sys subdir in the set of vendored files. And, since the subdir is likely to be another package on which the first package depends, it then vendors that package, thus including those files twice and resulting in a directory structure like:

* vendor/
  * foo/
    * …
    * foo-sys/
  * foo-sys/
    * …

This branch fixes the specific problem of a *-sys subdirectory by ignoring a directory with that name. I've tested it with both lmdb-rs and curl-rust (of which the included test uses the latter).

Nevertheless, it isn't clear to me that it's an optimal fix, as a *-sys subdir could theoretically be something other than a dependency, and perhaps there are other directories we would also want to exclude (such as the ones that cargo package excludes). Suggestions welcome!