### PR TITLE
Vendor sources into separate directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ $ cargo vendor > .cargo/config
 
 to vendor and initialize your config in the same step!
 
+### Flag `--no-merge-sources`
+
+If the vendored Cargo project makes use of `[replace]` sections it can happen
+that the vendoring operation fails, e.g. with an error like this:
+
+```
+found duplicate version of package `libc v0.2.43` vendored from two sources:
+...
+```
+
+The flag `--no-merge-sources` should be able to solve that. Make sure to grab
+the `.cargo/config` file directly from standard output since the config gets more
+complicated and unpredictable.
+
+Example:
+
+```
+$ cargo vendor --no-merge-sources > .cargo/config
+```
+
 # License
 
 This project is licensed under either of


### PR DESCRIPTION
I thought #59 could be addressed by keeping sources in separate directories and replacing them 1-to-1, instead of replacing all sources with a single merged source.
It seems to work so far. Currently it breaks most of the tests, if this is the way to go I'll fix the tests, incorporate any feedback and update the PR.