### PR TITLE
don't delete pre-existing crates from git sources

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,9 @@ fn sync(workspaces: &[Workspace],
             if pkg.source_id().is_path() {
                 continue
             }
+            if pkg.source_id().is_git() {
+                continue;
+            }
             if let Ok(pkg) = packages.get(pkg) {
                 drop(fs::remove_dir_all(pkg.manifest_path().parent().unwrap()));
             }

--- a/tests/vendor.rs
+++ b/tests/vendor.rs
@@ -349,6 +349,30 @@ fn dependent_crates_in_crates() {
 }
 
 #[test]
+fn vendoring_git_crates() {
+    let (dir, _lock) = dir();
+
+    file(&dir, "Cargo.toml", r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [dependencies.serde]
+        version = "=1.0.66"
+
+        [dependencies.serde_derive]
+        version = "=1.0.66"
+
+        [patch.crates-io]
+        serde_derive = { git = "https://github.com/servo/serde", branch = "deserialize_from_enums8" }
+    "#);
+    file(&dir, "src/lib.rs", "");
+
+    run(&mut vendor(&dir)
+        .env("CARGO_HOME", &dir.join("cargo_home")));
+}
+
+#[test]
 fn git_simple() {
     let (dir, _lock) = dir();
 


### PR DESCRIPTION
Otherwise we risk deleting real code that won't be redownloaded properly.

Fixes #140.